### PR TITLE
Update App Start Command for App Platform Deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start -H 0.0.0.0 -p ${PORT:-8080}"
   },
   "dependencies": {
     "@directus/sdk": "^10.3.0",


### PR DESCRIPTION
This PR changes the `start` command in our `package.json` file to better accommodate deployment on the App Platform. Specifically, we're adjusting the `start` command to specify the host and port.

## Changes

The previous `start` command was:

```json
"start": "next start"
```

The new `start` command is:
```json
"start": "next start -H 0.0.0.0 -p ${PORT:-8080}"
```

The `-H 0.0.0.0` option allows the Next.js app to listen on all IP addresses of the server (necessary for deployment), and `-p ${PORT:-8080}` specifies the port on which the server should run. The `PORT` environment variable will be used if it's available; otherwise, the server will default to port `8080`.

## Testing

After making this change, ensure that you can still start the Next.js app locally using `npm start` (you may need to set a `PORT` environment variable in your local environment if one isn't set).