### PR TITLE
Revert Codecov integration due to absence of tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,3 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm run build --if-present
-    - name: Test with coverage
-      run: npm run test:coverage
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }} # if required
-        fail_ci_if_error: true


### PR DESCRIPTION
This pull request reverts the previously added Codecov integration from our CI pipeline. The integration was initially added to track and monitor code coverage after every commit. However, since our current project does not contain any tests, the addition of a code coverage tool like Codecov is unnecessary and has led to CI failures.

Here are the primary changes:

1. The Github Actions CI workflow no longer includes a step for running tests or uploading a coverage report to Codecov. The configuration changes can be seen in `.github/workflows/ci.yml`.

In summary, this PR removes an unnecessary component from our CI process. Once we have tests in our project, we can consider reintroducing Codecov or a similar tool to help us measure and improve our test coverage.

Note: This PR only impacts the CI configuration and does not alter any functional aspect of the project.
